### PR TITLE
Argument parsing fix

### DIFF
--- a/src/secret_santa/core.clj
+++ b/src/secret_santa/core.clj
@@ -68,7 +68,7 @@
 
 (defn -main
   [& args]
-  (let [[options args banner] (cli args
+  (let [[options args banner] (cli (vec args)
                                    ["-e" "--examiner" "Email validator"]
                                    ["-h" "--help" "Display help" :default false :flag true]
                                    ["-o" "--originator" "The originator" :default "" :required true]


### PR DESCRIPTION
Hi-
This is a fix for the argument parsing in -main (when it gets passed to tools.cli/cli).  Seems to work, application as whole doesn't work for me without it.

-Robin K.
